### PR TITLE
Filtering by contact list id on the Contact resource

### DIFF
--- a/lib/promoter/contact.rb
+++ b/lib/promoter/contact.rb
@@ -19,10 +19,11 @@ module Promoter
       Contact.destroy(self.email)
     end
 
-    # Parameter     Optional?  Description
-    # page	        yes	       Returns which page of results to return.
-    #                          Defaults to 1
-    # email         yes        Filter the results by email address.
+    # Parameter         Optional?  Description
+    # page	            yes	       Returns which page of results to return. Defaults to 1
+    #
+    # email             yes        Filter the results by email address.
+    # contact_list_id   yes        Filter the results by contact list
     def self.all(options={})
       if !options.is_a?(Hash)
         puts "-- DEPRECATION WARNING--"
@@ -31,10 +32,15 @@ module Promoter
       else
         # default to first page
         options[:page] ||= 1
+
+        if options.key?(:contact_list_id)
+          options[:contact_list__id] = options.delete(:contact_list_id)
+        end
+
         query_string = URI.encode_www_form(options)
       end
       response = Request.get("#{API_URL}/?#{query_string}")
-      response['results'].map {|attrs| new(attrs)}
+      response['results'].map { |attrs| new(attrs) }
     end
 
     def self.find(id)


### PR DESCRIPTION
In the Promoter.io API, [this](http://docs.promoter.apiary.io/#reference/contacts/get-all-contacts-in-a-list/get-all-contacts-in-a-list) is now the only way to get contacts from a specific contact list:

```
https://app.promoter.io/api/contacts/?contact_list__id=1138
```

This PR just extends the `Contact.all` method so that it can filter by contact list id.
