### PR TITLE
Metric params & small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 promoter is a wrapper for the promoter.io REST API.
 
-You can find the promoter.io api docs here: http://docs.promoter.apiary.io/
+You can find the promoter.io API docs here: https://developers.promoter.io/v1.0/reference
 
 ## Installation
 

--- a/lib/promoter/metric.rb
+++ b/lib/promoter/metric.rb
@@ -7,7 +7,7 @@ module Promoter
     API_URL = "https://app.promoter.io/api/metrics"
 
     def initialize(attrs)
-      @campaign_name = attrs["campaign"]
+      @campaign_name = attrs["campaign_name"]
       @nps = attrs["nps"].to_f
       @organization_nps = attrs["organization_nps"].to_f
     end

--- a/lib/promoter/metric.rb
+++ b/lib/promoter/metric.rb
@@ -12,8 +12,9 @@ module Promoter
       @organization_nps = attrs["organization_nps"].to_f
     end
 
-    def self.all
-      response = Request.get("#{API_URL}/")
+    def self.all(options={})
+      query_string = URI.encode_www_form(options)
+      response = Request.get("#{API_URL}/?#{query_string}")
       response['results'].map {|attrs| new(attrs)}
     end
 

--- a/spec/fixtures/metrics.json
+++ b/spec/fixtures/metrics.json
@@ -4,7 +4,7 @@
     "previous": null,
     "results": [
         {
-            "campaign": "My Campaign",
+            "campaign_name": "My Campaign",
             "nps": "50.0",
             "organization_nps": "35.0"
         }

--- a/spec/metric_spec.rb
+++ b/spec/metric_spec.rb
@@ -4,7 +4,7 @@ describe Promoter::Metric do
 
   it 'returns all metrics' do
     stub_request(:get, "https://app.promoter.io/api/metrics/").
-         to_return(status: 204, body: fixture('metrics.json'))
+         to_return(status: 200, body: fixture('metrics.json'))
     result = Promoter::Metric.all
 
     expect(result.count).to eq(1)


### PR DESCRIPTION
* Adds the ability pass query params to metrics requests (from & to date)
* Updates the campaign name attribute to use the right attribute from the API response
* Updates the link to the API docs in the README