### PR TITLE
Even better error handling

### DIFF
--- a/lib/promoter/contact.rb
+++ b/lib/promoter/contact.rb
@@ -89,13 +89,13 @@ module Promoter
       contact_attributes = if Promoter.api_version == 2
         api_url = "https://app.promoter.io/api/v2"
         contact_params = {
-          attributes: params[:attributes],
+          attributes: params[:attributes] || {},
           email: params[:email],
           first_name: params[:first_name],
           last_name: params[:last_name]
         }
         survey_params = {
-          attributes: params[:survey_attributes],
+          attributes: params[:survey_attributes] || {},
           campaign_id: params[:campaign_id],
           contact: contact_params,
         }

--- a/lib/promoter/errors.rb
+++ b/lib/promoter/errors.rb
@@ -24,10 +24,10 @@ module Promoter
     # 429	Too Many Requests – You’re requesting too much! Slown down!
     # 500	Internal Server Error – We had a problem with our server. Try again later.
     # 503	Service Unavailable – We’re temporarially offline for maintanance. Please try again later.
-    def check_for_error(status_code)
+    def check_for_error(status_code, response_body)
       case status_code.to_i
       when 400
-        raise BadRequest.new("Something is wrong with your request")
+        raise BadRequest.new(response_body)
       when 401
         raise Unauthorized.new("Your API key is incorrect or invalid")
       when 403

--- a/lib/promoter/request.rb
+++ b/lib/promoter/request.rb
@@ -28,12 +28,13 @@ module Promoter
 
     def self.parse_response(response, response_format=:json)
       display_debug(response.body)
-      check_for_error(response.response.code)
-      if response_format == :json
-        JSON.parse(response.body.to_s)
-      else
-        response.body.to_s
-      end
+      response_body = begin
+                        JSON.parse(response.body.to_s)
+                      rescue
+                        response.body.to_s
+                      end
+      check_for_error(response.response.code, response_body)
+      response_body
     end
 
     def self.display_debug(response)

--- a/lib/promoter/version.rb
+++ b/lib/promoter/version.rb
@@ -1,3 +1,3 @@
 module Promoter
-  VERSION = "0.9.2"
+  VERSION = "0.9.3"
 end

--- a/spec/fixtures/v2/contact_blank_email.json
+++ b/spec/fixtures/v2/contact_blank_email.json
@@ -1,0 +1,7 @@
+{
+  "contact": {
+    "email": [
+      "This field may not be blank."
+    ]
+  }
+}

--- a/spec/fixtures/v2/contact_not_eligible.json
+++ b/spec/fixtures/v2/contact_not_eligible.json
@@ -1,0 +1,5 @@
+{
+  "non_field_errors": [
+    "Contact is not eligible for survey."
+  ]
+}

--- a/spec/v2/contact_spec.rb
+++ b/spec/v2/contact_spec.rb
@@ -27,4 +27,50 @@ describe Promoter::Contact do
     expect(contact.last_name).to eq("O'Sullivan")
     expect(contact.attributes).to eq({ "customer_id" => "7" })
   end
+
+  it "handles not eligible error gracefully" do
+    stub_request(:post, "https://app.promoter.io/api/v2/survey/").
+         to_return(status: 400, body: fixture("contact_not_eligible.json"))
+
+    contact_attributes = {
+      campaign: 99,
+      email: "chris@mac.com",
+      first_name: "Chris",
+      last_name: "O'Sullivan",
+      attributes: {
+        customer_id: "7"
+      },
+      survey_attributes: {
+        product: "Box of apples"
+      }
+    }
+
+    error = { "non_field_errors" => [ "Contact is not eligible for survey." ]}
+    expect {
+      Promoter::Contact.survey(contact_attributes)
+    }.to raise_error(Promoter::Errors::BadRequest, error.to_s)
+  end
+
+  it "handles missing fields gracefully" do
+    stub_request(:post, "https://app.promoter.io/api/v2/survey/").
+         to_return(status: 400, body: fixture("contact_blank_email.json"))
+
+    contact_attributes = {
+      campaign: 99,
+      email: "",
+      first_name: "Chris",
+      last_name: "O'Sullivan",
+      attributes: {
+        customer_id: "7"
+      },
+      survey_attributes: {
+        product: "Box of apples"
+      }
+    }
+
+    error = { "contact" => { "email" => ["This field may not be blank."] }}
+    expect {
+      Promoter::Contact.survey(contact_attributes)
+    }.to raise_error(Promoter::Errors::BadRequest, error.to_s)
+  end
 end


### PR DESCRIPTION
Let's feed through the validation errors to the consumer of the gem, so they can see what's going wrong.